### PR TITLE
Make `submitted` method public

### DIFF
--- a/src/Cgit/Postman.php
+++ b/src/Cgit/Postman.php
@@ -255,7 +255,7 @@ class Postman
      *
      * @return boolean
      */
-    private function submitted()
+    public function submitted()
     {
         $request = $this->request();
 


### PR DESCRIPTION
Methods relating to the state of the contact form are useful for contextually modifying the content around the form, particularly when leveraging `cgit-wp-postcard`