### PR TITLE
Log grouping control doesn't actually work

### DIFF
--- a/cgit-wp-postman.php
+++ b/cgit-wp-postman.php
@@ -5,7 +5,7 @@
 Plugin Name: Castlegate IT WP Postman
 Plugin URI: http://github.com/castlegateit/cgit-wp-postman
 Description: Flexible contact form plugin for WordPress.
-Version: 2.3
+Version: 2.4
 Author: Castlegate IT
 Author URI: http://www.castlegateit.co.uk/
 License: MIT

--- a/src/Cgit/Postman/Lumberjack.php
+++ b/src/Cgit/Postman/Lumberjack.php
@@ -308,19 +308,26 @@ class Lumberjack
      * Is this a valid download request?
      *
      * If we are looking at the wrong page or if we have not asked to download
-     * anything or if we have not specified a post or form ID to download, do
+     * anything or if we have not specified the log to download, do
      * nothing.
      *
      * @return boolean
      */
     private function isDownload()
     {
+        // Have we adequately specified which log we want?
+        $groups_all_present = true;
+        foreach ($this->groups as $group) {
+            if (!isset($_GET[$group])) {
+                $groups_all_present = false;
+            }
+        }
+
         return isset($_GET['page']) &&
             isset($_GET['download']) &&
-            (isset($_GET['post_id']) && isset($_GET['form_id'])) &&
+            $groups_all_present &&
             $_GET['page'] == 'cgit-postman-logs';
     }
-
     /**
      * Generate download file name
      *


### PR DESCRIPTION
Lumberjack's ability to group using the cgit_postman_log_groups filter is thwarted by the isDownload() function which expects a post_id and a form_id and will accept nothing less.