### PR TITLE
errors() method to return true if errors

### DIFF
--- a/classes/Cgit/Postman.php
+++ b/classes/Cgit/Postman.php
@@ -308,10 +308,10 @@ class Postman
     public function errors()
     {
         if ($this->errors) {
-            return false;
+            return true;
         };
 
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
It looks like errors() returns true if there are no errors and false if there are errors. This is counter-intuitive. But it may break MANY THINGS?