### PR TITLE
Log deletion method fix

### DIFF
--- a/cgit-wp-postman.php
+++ b/cgit-wp-postman.php
@@ -5,7 +5,7 @@
 Plugin Name: Castlegate IT WP Postman
 Plugin URI: http://github.com/castlegateit/cgit-wp-postman
 Description: Flexible contact form plugin for WordPress.
-Version: 2.8.8
+Version: 2.8.9
 Author: Castlegate IT
 Author URI: http://www.castlegateit.co.uk/
 License: AGPLv3

--- a/classes/Cgit/Postman/Lumberjack.php
+++ b/classes/Cgit/Postman/Lumberjack.php
@@ -522,7 +522,7 @@ class Lumberjack
         $date->modify('-' . $days . ' days');
         $sql_date = $date->format('Y-m-d H:i:s');
 
-        $this->deleted = $wpdb->query("DELETE FROM $table
+        $this->deleted = $this->database->query("DELETE FROM $table
             WHERE date < '$sql_date'");
     }
 


### PR DESCRIPTION
deleteExceptDays() is using $wpdb to run the deletion query instead of the database property.